### PR TITLE
Ensure GOPATH and reduce repeated commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 GOFILES = $(shell find . -name '*.go' -not -path './vendor/*')
 GOPACKAGES = github.com/datatogether/ffi github.com/multiformats/go-multihash github.com/PuerkitoBio/fetchbot github.com/PuerkitoBio/goquery github.com/PuerkitoBio/purell github.com/sirupsen/logrus github.com/spf13/cobra github.com/ugorji/go/codec github.com/dgraph-io/badger
 
+# Always ensure Go is set up properly
+ifndef GOPATH
+$(error $$GOPATH must be set. plz check: https://github.com/golang/go/wiki/SettingGOPATH)
+endif
 
 default: build
-
-require-gopath:
-	ifndef GOPATH
-		$(error $$GOPATH must be set. plz check: https://github.com/golang/go/wiki/SettingGOPATH)
-	endif
 
 install-deps:
 	go get -v -u $(GOPACKAGES)
@@ -18,10 +17,7 @@ list-deps:
 build:
 	go build
 
-install: 
-	@echo "\n1/2 install deps:\n"
-	go get -v -u $(GOPACKAGES)
-	@echo "\n2/2 build & install walk:\n"
+install: install-deps
 	go install
-	@echo "done!"
+	@echo "Walk is installed at `which walk`. Run \`walk --help\` for usage instructions."
 


### PR DESCRIPTION
I noticed we added an `install` target that repeats code from the `install-deps` target, so this uses a dependency to clean that up. While doing so, I also realized that a) we had a `require-gopath` target we didn't use and that b) it didn't work properly. It turns out you can't use control directives like this inside a target (among the many reasons I find make confusing as all get-out), but that's OK since we should probably always be ensuring `GOPATH` is set.